### PR TITLE
micro optimization

### DIFF
--- a/AI_BetterPenetration/AI_BetterPenetration.csproj
+++ b/AI_BetterPenetration/AI_BetterPenetration.csproj
@@ -117,4 +117,7 @@
   <Import Project="..\packages\IllusionLibs.AIGirl.UnityEngine.CoreModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.CoreModule.targets" Condition="Exists('..\packages\IllusionLibs.AIGirl.UnityEngine.CoreModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.CoreModule.targets')" />
   <Import Project="..\packages\IllusionLibs.AIShoujo.Assembly-CSharp.2019.12.20.4\build\IllusionLibs.AIShoujo.Assembly-CSharp.targets" Condition="Exists('..\packages\IllusionLibs.AIShoujo.Assembly-CSharp.2019.12.20.4\build\IllusionLibs.AIShoujo.Assembly-CSharp.targets')" />
   <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) AI</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/AI_Studio_BetterPenetration/AI_Studio_BetterPenetration.csproj
+++ b/AI_Studio_BetterPenetration/AI_Studio_BetterPenetration.csproj
@@ -133,4 +133,7 @@
   <Import Project="..\packages\IllusionLibs.AIGirl.UnityEngine.UI.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.UI.targets" Condition="Exists('..\packages\IllusionLibs.AIGirl.UnityEngine.UI.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.UI.targets')" />
   <Import Project="..\packages\IllusionLibs.AIGirl.UnityEngine.UIModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.UIModule.targets" Condition="Exists('..\packages\IllusionLibs.AIGirl.UnityEngine.UIModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.UIModule.targets')" />
   <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) AI</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Core_BetterPenetration/Tools.cs
+++ b/Core_BetterPenetration/Tools.cs
@@ -179,21 +179,40 @@ namespace Core_BetterPenetration
 
             foreach (var dynamicBone in dynamicBones)
             {
-                if (dynamicBone == null || dynamicBone.name == null || dynamicBone.m_Colliders == null)
+                if (!dynamicBone)
                     continue;
 
-                bool bpBone = dynamicBone.name.Contains("Vagina") || dynamicBone.name.Contains("Belly") || dynamicBone.name.Contains("Ana");
-                for (int collider = dynamicBone.m_Colliders.Count - 1; collider >= 0; collider--)
+                var dbName = dynamicBone.name;
+                var dbColliders = dynamicBone.m_Colliders;
+
+                if (dbName == null || dbColliders == null || dbColliders.Count <= 0)
+                    continue;
+
+                bool bpBone = dbName.Contains("Vagina") || dbName.Contains("Belly") || dbName.Contains("Ana");
+                int last = 0;
+
+                for (int collider = 0; collider < dbColliders.Count; ++collider)
                 {
-                    if (dynamicBone.m_Colliders[collider] == null || dynamicBone.m_Colliders[collider].name == null)
-                        continue;
+                    if (dbColliders[collider])
+                    {
+                        var colliderName = dbColliders[collider].name;
 
-                    bool bpCollider = dynamicBone.m_Colliders[collider].name.Contains("cm_J_vdan") || dynamicBone.m_Colliders[collider].name.Contains("cm_J_dan");
-                    if (bpBone == bpCollider)
-                        continue;
+                        if (colliderName != null)
+                        {
+                            bool bpCollider = colliderName.Contains("cm_J_vdan") || colliderName.Contains("cm_J_dan");
 
-                    dynamicBone.m_Colliders.RemoveAt(collider);
+                            if (bpBone != bpCollider)
+                                continue;   //remove collider
+                        }
+                    }
+
+                    //keep collider
+                    if (last != collider)
+                        dbColliders[last] = dbColliders[collider];
+                    ++last;
                 }
+
+                dbColliders.RemoveRange(last, dbColliders.Count - last);
             }
         }
     }

--- a/HS2_BetterPenetration/HS2_BetterPenetration.csproj
+++ b/HS2_BetterPenetration/HS2_BetterPenetration.csproj
@@ -91,4 +91,7 @@
   <Import Project="..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass.2020.5.29.4\build\IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass.targets" Condition="Exists('..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass.2020.5.29.4\build\IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass.targets')" />
   <Import Project="..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.targets" Condition="Exists('..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.targets')" />
   <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) HS2</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/HS2_Studio_BetterPenetration/HS2_Studio_BetterPenetration.csproj
+++ b/HS2_Studio_BetterPenetration/HS2_Studio_BetterPenetration.csproj
@@ -139,4 +139,7 @@
   <Import Project="..\packages\IllusionLibs.HoneySelect2.UnityEngine.UI.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.UI.targets" Condition="Exists('..\packages\IllusionLibs.HoneySelect2.UnityEngine.UI.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.UI.targets')" />
   <Import Project="..\packages\IllusionLibs.HoneySelect2.UnityEngine.UIModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.UIModule.targets" Condition="Exists('..\packages\IllusionLibs.HoneySelect2.UnityEngine.UIModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.UIModule.targets')" />
   <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) HS2</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/KKS_BetterPenetration/KKS_BetterPenetration.csproj
+++ b/KKS_BetterPenetration/KKS_BetterPenetration.csproj
@@ -90,4 +90,7 @@
   <Import Project="..\packages\IllusionLibs.KoikatsuSunshine.Assembly-CSharp.2021.9.17\build\IllusionLibs.KoikatsuSunshine.Assembly-CSharp.targets" Condition="Exists('..\packages\IllusionLibs.KoikatsuSunshine.Assembly-CSharp.2021.9.17\build\IllusionLibs.KoikatsuSunshine.Assembly-CSharp.targets')" />
   <Import Project="..\packages\IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass.2021.9.17\build\IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass.targets" Condition="Exists('..\packages\IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass.2021.9.17\build\IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass.targets')" />
   <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) KKS</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/KKS_Studio_BetterPenetration/KKS_Studio_BetterPenetration.csproj
+++ b/KKS_Studio_BetterPenetration/KKS_Studio_BetterPenetration.csproj
@@ -180,4 +180,7 @@
   <Import Project="..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.UIModule.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.UIModule.targets" Condition="Exists('..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.UIModule.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.UIModule.targets')" />
   <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets')" />
   <Import Project="..\packages\IllusionLibs.BepInEx.MonoMod.22.1.29.1\build\IllusionLibs.BepInEx.MonoMod.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.MonoMod.22.1.29.1\build\IllusionLibs.BepInEx.MonoMod.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) KKS</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/KK_BetterPenetration/KK_BetterPenetration.csproj
+++ b/KK_BetterPenetration/KK_BetterPenetration.csproj
@@ -92,4 +92,7 @@
   <Import Project="..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets')" />
   <Import Project="..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets')" />
   <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) KK</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/KK_Studio_BetterPenetration/KK_Studio_BetterPenetration.csproj
+++ b/KK_Studio_BetterPenetration/KK_Studio_BetterPenetration.csproj
@@ -111,4 +111,7 @@
   <Import Project="..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp.targets')" />
   <Import Project="..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets')" />
   <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.9.0\build\IllusionLibs.BepInEx.Harmony.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) KK</PostBuildEvent>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
The following two points have been changed.
Please review and merge.

- Add code to call PostBuild.bat in the post-build script

- Reduce GCAlloc
The profiler showed it was a problem, so I did some micro-optimization of the code.
At first I thought it was the O(N^2) code using RemoveAt, but it seemed to be caused by GCAlloc due to the reference to .name.

Changes in loading time for huge scenes:
Before, average: 36.84
```
Scene loading completed: 36.8[s]
Scene loading completed: 37.8[s]
Scene loading completed: 36.5[s]
Scene loading completed: 36.6[s]
Scene loading completed: 36.5[s]
```

After, average: 34.76 -2.08
```
Scene loading completed: 35.2[s]
Scene loading completed: 34.8[s]
Scene loading completed: 34.6[s]
Scene loading completed: 35.0[s]
Scene loading completed: 34.2[s]
```

Before profile:
![image](https://github.com/user-attachments/assets/dbd788ba-21e6-4020-833f-172751dc2236)
[MonoProfilerOutput_2024-08-25_13-23-16.csv](https://github.com/user-attachments/files/16746554/MonoProfilerOutput_2024-08-25_13-23-16.csv)

After profile:
![image](https://github.com/user-attachments/assets/840549be-6638-4f0c-9f56-2bff0541a300)
[MonoProfilerOutput_2024-08-26_17-31-48.csv](https://github.com/user-attachments/files/16746557/MonoProfilerOutput_2024-08-26_17-31-48.csv)


Memo:
There are 20 characters in this scene. The 1120 calls to RemoveCollidersFromCoordinate(ChaControl) seem excessive.