### PR TITLE
Reduce FindObjects

### DIFF
--- a/AI_Studio_BetterPenetration/AI_Studio_BetterPenetration.cs
+++ b/AI_Studio_BetterPenetration/AI_Studio_BetterPenetration.cs
@@ -241,11 +241,7 @@ namespace AI_Studio_BetterPenetration
 
         internal static void BeforeCharacterReload()
         {
-            var bpControllers = FindObjectsOfType<BetterPenetrationController>();
-            if (bpControllers == null)
-                return;
-
-            foreach (var controller in bpControllers)
+            foreach (var controller in BetterPenetrationController.controllers)
             { 
                 if (controller == null)
                     continue;
@@ -308,11 +304,7 @@ namespace AI_Studio_BetterPenetration
             if (nodeConstraintPlugin == null)
                 return;
 
-            var bpControllers = FindObjectsOfType<BetterPenetrationController>();
-            if (bpControllers == null)
-                return;
-
-            foreach (var controller in bpControllers)
+            foreach (var controller in BetterPenetrationController.controllers)
             {
                 if (controller == null)
                     continue;
@@ -335,11 +327,7 @@ namespace AI_Studio_BetterPenetration
 
             updateCount = 0;
 
-            var bpControllers = BetterPenetrationController.controllers;
-            if (bpControllers == null)
-                return;
-
-            foreach (var controller in bpControllers)
+            foreach (var controller in BetterPenetrationController.controllers)
             {
                 if (controller == null)
                     continue;

--- a/HS2_Studio_BetterPenetration/HS2_Studio_BetterPenetration.cs
+++ b/HS2_Studio_BetterPenetration/HS2_Studio_BetterPenetration.cs
@@ -241,11 +241,7 @@ namespace HS2_Studio_BetterPenetration
 
         internal static void BeforeCharacterReload()
         {
-            var bpControllers = FindObjectsOfType<BetterPenetrationController>();
-            if (bpControllers == null)
-                return;
-
-            foreach (var controller in bpControllers)
+            foreach (var controller in BetterPenetrationController.controllers)
             { 
                 if (controller == null)
                     continue;
@@ -308,11 +304,7 @@ namespace HS2_Studio_BetterPenetration
             if (nodeConstraintPlugin == null)
                 return;
 
-            var bpControllers = FindObjectsOfType<BetterPenetrationController>();
-            if (bpControllers == null)
-                return;
-
-            foreach (var controller in bpControllers)
+            foreach (var controller in BetterPenetrationController.controllers)
             {
                 if (controller == null)
                     continue;
@@ -335,11 +327,7 @@ namespace HS2_Studio_BetterPenetration
 
             updateCount = 0;
 
-            var bpControllers = BetterPenetrationController.controllers;
-            if (bpControllers == null)
-                return;
-
-            foreach (var controller in bpControllers)
+            foreach (var controller in BetterPenetrationController.controllers)
             {
                 if (controller == null)
                     continue;

--- a/KKS_Studio_BetterPenetration/KKS_Studio_BetterPenetration.cs
+++ b/KKS_Studio_BetterPenetration/KKS_Studio_BetterPenetration.cs
@@ -240,11 +240,7 @@ namespace KKS_Studio_BetterPenetration
 
         internal static void BeforeCharacterReload()
         {
-            var bpControllers = FindObjectsOfType<BetterPenetrationController>();
-            if (bpControllers == null)
-                return;
-
-            foreach (var controller in bpControllers)
+            foreach (var controller in BetterPenetrationController.controllers)
             { 
                 if (controller == null)
                     continue;
@@ -307,11 +303,7 @@ namespace KKS_Studio_BetterPenetration
             if (nodeConstraintPlugin == null)
                 return;
 
-            var bpControllers = FindObjectsOfType<BetterPenetrationController>();
-            if (bpControllers == null)
-                return;
-
-            foreach (var controller in bpControllers)
+            foreach (var controller in BetterPenetrationController.controllers)
             {
                 if (controller == null)
                     continue;
@@ -334,11 +326,7 @@ namespace KKS_Studio_BetterPenetration
 
             updateCount = 0;
 
-            var bpControllers = BetterPenetrationController.controllers;
-            if (bpControllers == null)
-                return;
-
-            foreach (var controller in bpControllers)
+            foreach (var controller in BetterPenetrationController.controllers)
             {
                 if (controller == null)
                     continue;

--- a/KK_Studio_BetterPenetration/KK_Studio_BetterPenetration.cs
+++ b/KK_Studio_BetterPenetration/KK_Studio_BetterPenetration.cs
@@ -240,11 +240,7 @@ namespace KK_Studio_BetterPenetration
 
         internal static void BeforeCharacterReload()
         {
-            var bpControllers = FindObjectsOfType<BetterPenetrationController>();
-            if (bpControllers == null)
-                return;
-
-            foreach (var controller in bpControllers)
+            foreach (var controller in BetterPenetrationController.controllers)
             { 
                 if (controller == null)
                     continue;
@@ -307,11 +303,7 @@ namespace KK_Studio_BetterPenetration
             if (nodeConstraintPlugin == null)
                 return;
 
-            var bpControllers = FindObjectsOfType<BetterPenetrationController>();
-            if (bpControllers == null)
-                return;
-
-            foreach (var controller in bpControllers)
+            foreach (var controller in BetterPenetrationController.controllers)
             {
                 if (controller == null)
                     continue;
@@ -334,11 +326,7 @@ namespace KK_Studio_BetterPenetration
 
             updateCount = 0;
 
-            var bpControllers = BetterPenetrationController.controllers;
-            if (bpControllers == null)
-                return;
-
-            foreach (var controller in bpControllers)
+            foreach (var controller in BetterPenetrationController.controllers)
             {
                 if (controller == null)
                     continue;


### PR DESCRIPTION
I reduced the number of calls to FindObjects.

I've checked that `FindObjectsOfType<BetterPenetrationController>().Length` and `BetterPenetrationController.controllers.Count` match up in the rewritten section. It should be safe.
Please review and merge.

Changes in loading time for huge scenes:

Before average 33.82
```
Scene loading completed: 33.7[s]
Scene loading completed: 33.6[s]
Scene loading completed: 33.9[s]
Scene loading completed: 34.2[s]
Scene loading completed: 33.7[s]
```

After average 33.3 -0.52
```
Scene loading completed: 33.2[s]
Scene loading completed: 33.3[s]
Scene loading completed: 33.5[s]
Scene loading completed: 33.3[s]
Scene loading completed: 33.2[s]
```