### PR TITLE
Fix duplicate dan constraints on scene load

### DIFF
--- a/Core_BetterPenetration/BetterPenetrationController.cs
+++ b/Core_BetterPenetration/BetterPenetrationController.cs
@@ -416,7 +416,9 @@ namespace Core_BetterPenetration
             if (!danTargetsValid || collisionAgent == null || collisionAgent.m_collisionCharacter == null)
                 return;
 
-            if (danEntryConstraint != null)
+            // On reload there's no explicit parent so it's looked up by name, which can match a different same-named
+            // object and stack a second link on the same bone. Skip if this bone is already constrained.
+            if (danEntryConstraint != null && (danEntryParent != null || !DanBoneAlreadyConstrained(plugin, danEntryChild)))
             {
                 var parentTransform = danEntryParent;
                 if (parentTransform == null && !danEntryParentName.IsNullOrEmpty())
@@ -434,7 +436,7 @@ namespace Core_BetterPenetration
                 }
             }
 
-            if (danEndConstraint != null)
+            if (danEndConstraint != null && (danEndParent != null || !DanBoneAlreadyConstrained(plugin, danEndChild)))
             {
                 var parentTransform = danEndParent;
                 if (parentTransform == null && !danEndParentName.IsNullOrEmpty())
@@ -451,6 +453,29 @@ namespace Core_BetterPenetration
                             .GetValue(danEndConstraint);
                 }
             }
+        }
+
+        // True if NodesConstraints already has a constraint whose child is this dan bone.
+        private bool DanBoneAlreadyConstrained(BaseUnityPlugin plugin, Transform danBone)
+        {
+            if (danBone == null)
+                return false;
+
+            IList constraintsList = Traverse.Create(plugin).Field<IList>("_constraints").Value;
+            if (constraintsList == null)
+                return false;
+
+            foreach (var constraint in constraintsList)
+            {
+                if (constraint == null)
+                    continue;
+
+                Transform childTransform = Traverse.Create(constraint).Field<Transform>("childTransform").Value;
+                if (childTransform == danBone)
+                    return true;
+            }
+
+            return false;
         }
 
         public void RemoveDanConstraints(BaseUnityPlugin plugin)


### PR DESCRIPTION
## Description

Loading a studio scene can leave two NodesConstraints links on the same k_f_dan_end, and it adds another every time you reload. About a second after load ReinitializeControllers re-adds the dan constraints with no explicit parent, so AddDanConstraints looks the parent up by name inside the female. If that name matches a different transform than the one that's already constrained, NodesConstraints doesn't dedupe it (it only skips an exact parent+child pair) and you get a second link.

The fix checks whether the bone already has a constraint before re-adding it on that no-parent path, reusing the _constraints lookup RemoveDanConstraints already does. The normal auto-target path passes an explicit parent, so it's untouched.

## Motivation and Context

Every scene load stacks another duplicate constraint on the same dan bone, so a scene keeps accumulating junk links. Auto-Target Off doesn't stop it since it doesn't gate this path, and toggling Enable BP Controller triggers the same re-add.

## How Has This Been Tested?

KK CharaStudio, BP 5.0.1.5. To reproduce: put a male (BP controller on) and a female in a scene, constrain k_f_dan_entry/k_f_dan_end to a "Sphere", make a second item with the same name and parent it under the female, then save and load. Stock BP adds a second link to k_f_dan_end and stacks another on every reload; with the patch it stays at one. The change is in shared Core, so it covers KK/KKS/HS2/AI (built KKS as well to confirm).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
