### PR TITLE
Fix FK nodes holding the penis bones after a scene load

### DIFF
--- a/Core_BetterPenetration/BetterPenetrationController.cs
+++ b/Core_BetterPenetration/BetterPenetrationController.cs
@@ -1,6 +1,8 @@
 ﻿#if Studio
 using KKAPI;
 using KKAPI.Chara;
+using KKAPI.Studio;
+using Studio;
 using UnityEngine;
 using ExtensibleSaveFormat;
 using System.Linq;
@@ -324,6 +326,37 @@ namespace Core_BetterPenetration
             InitializeTama();
         }
 
+        // Some of the dan bones have Studio FK nodes in the shared Body group, so a scene saved with body FK on
+        // comes back with FKCtrl holding them over the dan agent's pose. Releases only the dan bones from FK.
+        public void ReleaseDanBonesFromFK(OCIChar ociChar = null)
+        {
+            // Only once a target has been picked up, so an unused penis can still be posed by hand.
+            if (!danTargetsValid || !enabled || danAgent == null || !danAgent.m_danPointsFound ||
+                collisionAgent == null || collisionAgent.m_collisionCharacter == null)
+                return;
+
+            if (ociChar == null)
+                ociChar = ChaControl.GetOCIChar();
+
+            if (ociChar == null || ociChar.fkCtrl == null)
+                return;
+
+            foreach (var targetInfo in ociChar.fkCtrl.listBones)
+            {
+                if (targetInfo == null || !targetInfo.enable || targetInfo.gameObject == null)
+                    continue;
+
+                if (IsDanBone(targetInfo.gameObject.name))
+                    targetInfo.enable = false;
+            }
+        }
+
+        private static bool IsDanBone(string boneName)
+        {
+            return BoneNames.DanBones.Contains(boneName) || BoneNames.VirtualDanBones.Contains(boneName) ||
+                   boneName == BoneNames.BPDanEnd || boneName == BoneNames.TamaTop;
+        }
+
         public void ClearTama()
         {
             if (danAgent == null)
@@ -369,6 +402,9 @@ namespace Core_BetterPenetration
                 danAgent.AddDanCollidersToTargetAna(collisionAgent.m_collisionCharacter);
 
             danAgent.AddTamaColliders(collisionAgent.m_collisionCharacter, false);
+
+            // Now driving the shaft at a target, so it can't stay parked on an FK node.
+            ReleaseDanBonesFromFK();
         }
         
         public void SetBellyColliders(bool enable)

--- a/Core_BetterPenetration/Studio_BetterPenetration.cs
+++ b/Core_BetterPenetration/Studio_BetterPenetration.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using KKAPI.Studio;
 using KKAPI.Studio.UI;
 using KKAPI.Chara;
+using Studio;
 using UniRx;
 using System;
 using System.Linq;
@@ -117,6 +118,7 @@ namespace Core_BetterPenetration
                         controller.enabled = true;
                         controller.InitializeDanAgent();
                         controller.AddDanConstraints(nodeConstraintPlugin);
+                        controller.ReleaseDanBonesFromFK();
                     }
                 }
             });
@@ -315,6 +317,31 @@ namespace Core_BetterPenetration
 
                 controller.InitializeDanAgent();
                 controller.AddDanConstraints(nodeConstraintPlugin);
+                controller.ReleaseDanBonesFromFK();
+            }
+        }
+
+        // FK is restored for the saved groups a moment after a scene loads, and set again from the FK panel while
+        // posing, so the dan bones have to come back out of it whenever that happens. Runs for both on and off
+        // since the nodes AdditionalFKNodes just added start out enabled either way.
+        [HarmonyPostfix, HarmonyPatch(typeof(OCIChar), nameof(OCIChar.ActiveFK))]
+        internal static void OCIChar_ActiveFK(OCIChar __instance)
+        {
+            // Runs on the character load path for every character, so don't let an exception escape.
+            try
+            {
+                if (__instance.charInfo == null)
+                    return;
+
+                var controller = __instance.charInfo.GetComponent<BetterPenetrationController>();
+                if (controller == null)
+                    return;
+
+                controller.ReleaseDanBonesFromFK(__instance);
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogError("Studio_BetterPenetration: failed to release the dan bones from FK: " + e);
             }
         }
 


### PR DESCRIPTION
## Description

Several of the penis dan bones have Studio FK nodes on them, and those nodes sit in the shared Body
group. A scene saved with body FK on then comes back with FKCtrl holding those bones over the pose the
dan agent gives them. Only part of the shaft has nodes, so it loads kinked, which usually shows up as
the penis clipping through the body.

To reproduce: put a male with a BP uncensor and a female in a scene, aim BP at her, turn FK on for the
male, then save and load. The shaft comes back kinked and stays that way until FK is toggled off and on
again. Body is one of the two groups that default to on, so this happens as soon as FK is enabled at
all, you don't have to turn Body on yourself.

This switches FK off for just the dan bones BP poses and leaves every other bone in the group alone,
so the rest of the body keeps whatever FK the scene had. It runs whenever FK is set, when a collision
target is picked up, and after the studio reinitialize, since the saved FK state is restored a moment
after the scene finishes loading.

Only once BP has been aimed at someone. A penis nobody is using is left alone so it can still be posed
by hand, and a character without BP bones is never touched. The ball pivots are dynamic bones that are
never posed, so they keep their FK too.

## Motivation and Context

This looks like the cause of Animal42069/BetterPenetration#16 and the penis half of
Animal42069/BetterPenetration#35. The "disable and then re-enable IK/FK" workaround in #16 is the same
thing this does, per bone and without having to do it by hand on every load.

## How Has This Been Tested?

KK CharaStudio on HF Patch with BP 5.0.1.5 and AdditionalFKNodes 1.2.1, and KKS CharaStudio with BP
5.0.1.5. The scene above loads kinked and needs the FK toggle on stock BP, and follows the target with
the patch, across repeated reloads. KK gets the most of it since the uncensor adds FK nodes for
dan103/105/107/119 on top of the stock dan101/dan109/dan_f_top, KKS only has the stock three.

Also checked that FK on the rest of the skeleton still restores and behaves normally, that setting FK
during a scene leaves the shaft on BP, that a penis with no target can still be FK posed by hand, and
that posing the dan bones through KKPE still works.

The change is in shared Core so it builds for KK, KKS, HS2 and AI, but I only have KK and KKS to test
in, so it is untested on HS2 and AI. It should behave the same since it only touches the dan bones from
BoneNames, though HS2/AI register their FK nodes by bone id rather than by name, so sync bones there are
out of scope.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
